### PR TITLE
Avoid 3 known debconf prompts during deployment.

### DIFF
--- a/raspberrypi/files/avoid-debconf-prompts
+++ b/raspberrypi/files/avoid-debconf-prompts
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# A number of packages are going to ask questions via debconf prompts. Since we
+# know which answers are the right ones, set the right values and mark those
+# questions as seen, instead of having users follow documentation.
+#
+# See https://github.com/PiRogueToolSuite/pirogue-images/issues/3
+#
+# Reminder: debconf-set-selections comes with debconf, debconf-get-selections is
+# shipped in the debconf-utils package (not installed by default).
+set -e
+
+cat <<EOF | debconf-set-selections -v
+iptables-persistent iptables-persistent/autosave_v4 boolean false
+iptables-persistent iptables-persistent/autosave_v4 seen true
+iptables-persistent iptables-persistent/autosave_v6 boolean false
+iptables-persistent iptables-persistent/autosave_v6 seen true
+
+wireshark-common wireshark-common/install-setuid boolean true
+wireshark-common wireshark-common/install-setuid seen true
+EOF

--- a/raspberrypi/recipes/pi3-pi4.sh
+++ b/raspberrypi/recipes/pi3-pi4.sh
@@ -33,4 +33,8 @@ toast_me() {
   # Add PTS PPA
   chroot $MNT wget -O /etc/apt/sources.list.d/pirogue.list https://pts-project.org/debian-12/pirogue.list
   chroot $MNT wget -O /etc/apt/trusted.gpg.d/pirogue.asc   https://pts-project.org/debian-12/Key.gpg
+
+  # Make initial installation easier on users:
+  install -m 755 -o root -g root files/avoid-debconf-prompts $MNT/root/avoid-debconf-prompts
+  chroot $MNT /root/avoid-debconf-prompts && rm -f $MNT/root/avoid-debconf-prompts
 }

--- a/raspberrypi/recipes/pi5.sh
+++ b/raspberrypi/recipes/pi5.sh
@@ -34,6 +34,10 @@ toast_me() {
   chroot $MNT wget -O /etc/apt/sources.list.d/pirogue.list https://pts-project.org/debian-12/pirogue.list
   chroot $MNT wget -O /etc/apt/trusted.gpg.d/pirogue.asc   https://pts-project.org/debian-12/Key.gpg
 
+  # Make initial installation easier on users:
+  install -m 755 -o root -g root files/avoid-debconf-prompts $MNT/root/avoid-debconf-prompts
+  chroot $MNT /root/avoid-debconf-prompts && rm -f $MNT/root/avoid-debconf-prompts
+
   ### BEGIN: Pi 5 section
 
   # Preconfigure raspi-firmware to disable the default cma= setting on the


### PR DESCRIPTION
Even if those prompts and the associated answers are already documented in “Beginner guide - How to setup a PiRogue”, it's a bit annoying to have to go through them every time a new PiRogue is set up.

Let's pick the right answers (moving away from the default every time), and mark those questions as seen (i.e. asked and answered):

 - Save current IPv4 rules?                           Yes → No
 - Save current IPv6 rules?                           Yes → No
 - Should non-superusers be able to capture packets?  No → Yes

Link: https://github.com/PiRogueToolSuite/pirogue-images/issues/3